### PR TITLE
Add one-shot sync support, and expose `ExchangeScope`

### DIFF
--- a/echo/api/echo.api
+++ b/echo/api/echo.api
@@ -28,8 +28,8 @@ public abstract interface class io/github/alexandrepiveteau/echo/Site : io/githu
 }
 
 public final class io/github/alexandrepiveteau/echo/SiteKt {
-	public static final fun orderedMutableSite-DIH5q_I (ILjava/lang/Object;Lio/github/alexandrepiveteau/echo/core/log/MutableProjection;Lkotlinx/serialization/KSerializer;Lkotlinx/serialization/BinaryFormat;[Lkotlin/Pair;Lkotlin/jvm/functions/Function1;)Lio/github/alexandrepiveteau/echo/MutableSite;
-	public static final fun orderedSite (Ljava/lang/Object;Lio/github/alexandrepiveteau/echo/core/log/MutableProjection;Lkotlinx/serialization/KSerializer;Lkotlinx/serialization/BinaryFormat;[Lkotlin/Pair;Lkotlin/jvm/functions/Function1;)Lio/github/alexandrepiveteau/echo/Site;
+	public static final fun orderedMutableSite-NmxoKHA (ILjava/lang/Object;Lio/github/alexandrepiveteau/echo/core/log/MutableProjection;Lkotlinx/serialization/KSerializer;Lkotlinx/serialization/BinaryFormat;[Lkotlin/Pair;Lio/github/alexandrepiveteau/echo/sync/SyncStrategy;Lkotlin/jvm/functions/Function1;)Lio/github/alexandrepiveteau/echo/MutableSite;
+	public static final fun orderedSite (Ljava/lang/Object;Lio/github/alexandrepiveteau/echo/core/log/MutableProjection;Lkotlinx/serialization/KSerializer;Lkotlinx/serialization/BinaryFormat;[Lkotlin/Pair;Lio/github/alexandrepiveteau/echo/sync/SyncStrategy;Lkotlin/jvm/functions/Function1;)Lio/github/alexandrepiveteau/echo/Site;
 }
 
 public final class io/github/alexandrepiveteau/echo/SyncKt {
@@ -88,6 +88,22 @@ public final class io/github/alexandrepiveteau/echo/projections/TwoWayMutablePro
 public abstract interface class io/github/alexandrepiveteau/echo/projections/TwoWayProjection {
 	public abstract fun backward-xbSDizI (Ljava/lang/Object;JLjava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
 	public abstract fun forward-JkDpjPE (Lio/github/alexandrepiveteau/echo/projections/ChangeScope;Ljava/lang/Object;JLjava/lang/Object;)Ljava/lang/Object;
+}
+
+public abstract interface class io/github/alexandrepiveteau/echo/protocol/ExchangeScope : kotlinx/coroutines/channels/ReceiveChannel, kotlinx/coroutines/channels/SendChannel {
+	public abstract fun getOnEventLogLock ()Lkotlinx/coroutines/selects/SelectClause1;
+	public abstract fun getOnEventLogUpdate ()Lkotlinx/coroutines/selects/SelectClause0;
+	public abstract fun getOnMutableEventLogLock ()Lkotlinx/coroutines/selects/SelectClause1;
+	public abstract fun withEventLogLock (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun withMutableEventLogLock (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class io/github/alexandrepiveteau/echo/protocol/ExchangeScope$DefaultImpls {
+	public static synthetic fun cancel (Lio/github/alexandrepiveteau/echo/protocol/ExchangeScope;)V
+	public static fun getOnReceiveOrNull (Lio/github/alexandrepiveteau/echo/protocol/ExchangeScope;)Lkotlinx/coroutines/selects/SelectClause1;
+	public static fun offer (Lio/github/alexandrepiveteau/echo/protocol/ExchangeScope;Ljava/lang/Object;)Z
+	public static fun poll (Lio/github/alexandrepiveteau/echo/protocol/ExchangeScope;)Ljava/lang/Object;
+	public static fun receiveOrNull (Lio/github/alexandrepiveteau/echo/protocol/ExchangeScope;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract class io/github/alexandrepiveteau/echo/protocol/Message {
@@ -251,5 +267,16 @@ public final class io/github/alexandrepiveteau/echo/protocol/Message$Outgoing$Re
 public final class io/github/alexandrepiveteau/echo/sites/TransformsKt {
 	public static final fun map (Lio/github/alexandrepiveteau/echo/MutableSite;Lkotlin/jvm/functions/Function1;)Lio/github/alexandrepiveteau/echo/MutableSite;
 	public static final fun map (Lkotlinx/coroutines/flow/StateFlow;Lkotlin/jvm/functions/Function1;)Lkotlinx/coroutines/flow/StateFlow;
+}
+
+public abstract interface class io/github/alexandrepiveteau/echo/sync/SyncStrategy {
+	public static final field Companion Lio/github/alexandrepiveteau/echo/sync/SyncStrategy$Companion;
+	public abstract fun incoming (Lio/github/alexandrepiveteau/echo/protocol/ExchangeScope;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun outgoing (Lio/github/alexandrepiveteau/echo/protocol/ExchangeScope;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class io/github/alexandrepiveteau/echo/sync/SyncStrategy$Companion {
+	public final fun getContinuous ()Lio/github/alexandrepiveteau/echo/sync/SyncStrategy;
+	public final fun getOnce ()Lio/github/alexandrepiveteau/echo/sync/SyncStrategy;
 }
 

--- a/echo/src/commonMain/kotlin/io/github/alexandrepiveteau/echo/protocol/ExchangeScope.kt
+++ b/echo/src/commonMain/kotlin/io/github/alexandrepiveteau/echo/protocol/ExchangeScope.kt
@@ -15,7 +15,7 @@ import kotlinx.coroutines.selects.SelectClause1
  * @param I the type of the incoming messages.
  * @param O the type of the outgoing messages.
  */
-internal interface ExchangeScope<out I, in O> : ReceiveChannel<I>, SendChannel<O> {
+interface ExchangeScope<out I, in O> : ReceiveChannel<I>, SendChannel<O> {
 
   /**
    * Executes the given [block] on the [EventLog] with global exclusion. Because the [EventLog] may

--- a/echo/src/commonMain/kotlin/io/github/alexandrepiveteau/echo/sync/SyncStrategy.kt
+++ b/echo/src/commonMain/kotlin/io/github/alexandrepiveteau/echo/sync/SyncStrategy.kt
@@ -1,0 +1,71 @@
+package io.github.alexandrepiveteau.echo.sync
+
+import io.github.alexandrepiveteau.echo.protocol.*
+import io.github.alexandrepiveteau.echo.protocol.Message.Incoming as I
+import io.github.alexandrepiveteau.echo.protocol.Message.Outgoing as O
+
+/**
+ * An interface defining the strategy that will implement the replication protocol. A [SyncStrategy]
+ * defines the behavior for both sides of the replication protocol.
+ */
+sealed interface SyncStrategy {
+
+  /**
+   * Describes the outgoing side of the [SyncStrategy], which will receive some [I] and send some
+   * [O] to the other side.
+   */
+  suspend fun ExchangeScope<I, O>.outgoing()
+
+  /**
+   * Describes the incoming side of the [SyncStrategy], which will receive some [O] and send some
+   * [I] to the other side.
+   */
+  suspend fun ExchangeScope<O, I>.incoming()
+
+  companion object {
+
+    /**
+     * A [SyncStrategy] that stops sync between two sites only whenever the other side closes the
+     * communication channel. You'll typically want to use this for background sync.
+     */
+    val Continuous: SyncStrategy = SyncContinuous
+
+    /**
+     * A [SyncStrategy] that syncs between two sites, and stops when all the advertised events
+     * (before the [I.Ready] message) have been sent or received. You'll typically want to use this
+     * for foreground, user-initiated one-shot sync.
+     */
+    val Once: SyncStrategy = SyncOnce
+  }
+}
+
+private object SyncContinuous : SyncStrategy {
+  override suspend fun ExchangeScope<I, O>.outgoing() = runCatchingTermination {
+    awaitEvents(
+        advertisements = awaitAdvertisements(),
+        stopAfterAdvertised = false,
+    )
+  }
+
+  override suspend fun ExchangeScope<O, I>.incoming() = runCatchingTermination {
+    outgoingSending(
+        advertised = outgoingAdvertiseAll(),
+        stopAfterAdvertised = false,
+    )
+  }
+}
+
+private object SyncOnce : SyncStrategy {
+  override suspend fun ExchangeScope<I, O>.outgoing() = runCatchingTermination {
+    awaitEvents(
+        advertisements = awaitAdvertisements(),
+        stopAfterAdvertised = true,
+    )
+  }
+  override suspend fun ExchangeScope<O, I>.incoming() = runCatchingTermination {
+    outgoingSending(
+        advertised = outgoingAdvertiseAll(),
+        stopAfterAdvertised = true,
+    )
+  }
+}

--- a/echo/src/commonTest/kotlin/io/github/alexandrepiveteau/echo/site/MutableSiteEventTest.kt
+++ b/echo/src/commonTest/kotlin/io/github/alexandrepiveteau/echo/site/MutableSiteEventTest.kt
@@ -7,10 +7,10 @@ import io.github.alexandrepiveteau.echo.core.causality.toSiteIdentifier
 import io.github.alexandrepiveteau.echo.mutableSite
 import io.github.alexandrepiveteau.echo.suspendTest
 import io.github.alexandrepiveteau.echo.sync
+import io.github.alexandrepiveteau.echo.sync.SyncStrategy
 import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlinx.coroutines.withTimeoutOrNull
 
 class MutableSiteEventTest {
 
@@ -53,11 +53,10 @@ class MutableSiteEventTest {
 
   @Test
   fun sequential_yields_areOrdered() = suspendTest {
-    val alice = mutableSite<Int>(Random.nextSiteIdentifier())
-    val bob = mutableSite<Int>(Random.nextSiteIdentifier())
+    val alice = mutableSite<Int>(Random.nextSiteIdentifier(), strategy = SyncStrategy.Once)
+    val bob = mutableSite<Int>(Random.nextSiteIdentifier(), strategy = SyncStrategy.Once)
     alice.event { assertEquals(SequenceNumber.Min + 0u, yield(123).seqno) }
-    // TODO : Use one-shot sync when supported.
-    withTimeoutOrNull(100) { sync(alice, bob) }
+    sync(alice, bob)
     bob.event { assertEquals(SequenceNumber.Min + 1u, yield(123).seqno) }
   }
 }

--- a/echo/src/commonTest/kotlin/io/github/alexandrepiveteau/echo/site/MutableSiteSyncTest.kt
+++ b/echo/src/commonTest/kotlin/io/github/alexandrepiveteau/echo/site/MutableSiteSyncTest.kt
@@ -7,6 +7,8 @@ import io.github.alexandrepiveteau.echo.protocol.Message.Incoming
 import io.github.alexandrepiveteau.echo.protocol.Message.Outgoing
 import io.github.alexandrepiveteau.echo.suspendTest
 import io.github.alexandrepiveteau.echo.sync
+import io.github.alexandrepiveteau.echo.sync.SyncStrategy.Companion.Continuous
+import io.github.alexandrepiveteau.echo.sync.SyncStrategy.Companion.Once
 import kotlin.random.Random
 import kotlin.test.Test
 
@@ -17,5 +19,38 @@ class MutableSiteSyncTest {
     val site = mutableSite<Unit>(Random.nextSiteIdentifier())
     val link = link<Incoming, Outgoing> {}
     sync(site.incoming(), link)
+  }
+
+  @Test
+  fun syncOnce_noProjection_terminates() = suspendTest {
+    val alice = mutableSite<Unit>(Random.nextSiteIdentifier(), strategy = Once)
+    val bob = mutableSite<Unit>(Random.nextSiteIdentifier(), strategy = Once)
+
+    alice.event { yield(Unit) }
+    sync(alice, bob)
+    alice.event { yield(Unit) }
+    bob.event { yield(Unit) }
+    sync(alice, bob)
+  }
+
+  @Test
+  // Bug reproducer
+  fun syncOnce_projection_terminates() = suspendTest {
+    val alice =
+        mutableSite<Unit>(
+            identifier = Random.nextSiteIdentifier(),
+            strategy = Continuous,
+        )
+    val bob =
+        mutableSite<Unit>(
+            identifier = Random.nextSiteIdentifier(),
+            strategy = Once,
+        )
+
+    alice.event { yield(Unit) }
+    sync(alice, bob)
+    alice.event { yield(Unit) }
+    // bob.event { yield(Unit) }
+    sync(alice, bob)
   }
 }


### PR DESCRIPTION
This PR adds supports for one-shot sync. Additionally, it exposes the `ExchangeScope` and `SyncStrategy` interfaces, that describe how the sync protocol may interact with the event log and the other side.

The tests that were previously relying on `withTimeout(...) {}` now use the `SyncStrategy.Once` implementation, and all the `Site` builders now take an optional `SyncStrategy` parameter when they're created.