### PR TITLE
Optimize exchanges with no projections

### DIFF
--- a/echo-core/src/commonMain/kotlin/io/github/alexandrepiveteau/echo/core/log/Builders.kt
+++ b/echo-core/src/commonMain/kotlin/io/github/alexandrepiveteau/echo/core/log/Builders.kt
@@ -38,7 +38,7 @@ fun <T> mutableHistoryOf(
     }
 
 /** Creates a new [MutableEventLog], with no aggregate. */
-fun mutableEventLogOf(): MutableEventLog = mutableHistoryOf(NoModel, NoProjection)
+fun mutableEventLogOf(): MutableEventLog = mutableEventLogOf(*emptyArray())
 
 /**
  * Creates a new [MutableEventLog], with no aggregate.
@@ -47,30 +47,9 @@ fun mutableEventLogOf(): MutableEventLog = mutableHistoryOf(NoModel, NoProjectio
  */
 fun mutableEventLogOf(
     vararg events: Pair<EventIdentifier, ByteArray>,
-): MutableEventLog = mutableHistoryOf(NoModel, NoProjection, *events)
-
-// An object which represents the absence of an aggregated model.
-private object NoModel
-
-// An object which represents the absence of an aggregating projection.
-private object NoProjection : MutableProjection<NoModel> {
-
-  override fun ChangeScope.forward(
-      model: NoModel,
-      identifier: EventIdentifier,
-      data: ByteArray,
-      from: Int,
-      until: Int,
-  ): NoModel = NoModel
-
-  override fun backward(
-      model: NoModel,
-      identifier: EventIdentifier,
-      data: ByteArray,
-      from: Int,
-      until: Int,
-      changeData: ByteArray,
-      changeFrom: Int,
-      changeUntil: Int,
-  ): NoModel = NoModel
-}
+): MutableEventLog =
+    MutableEventLogImpl().apply {
+      for ((id, body) in events) {
+        insert(id.seqno, id.site, body)
+      }
+    }

--- a/echo-core/src/commonMain/kotlin/io/github/alexandrepiveteau/echo/core/log/MutableEventLogImpl.kt
+++ b/echo-core/src/commonMain/kotlin/io/github/alexandrepiveteau/echo/core/log/MutableEventLogImpl.kt
@@ -1,0 +1,169 @@
+package io.github.alexandrepiveteau.echo.core.log
+
+import io.github.alexandrepiveteau.echo.core.causality.*
+import io.github.alexandrepiveteau.echo.core.requireRange
+
+/**
+ * An implementation of [MutableEventLog], which stores events by site as well as in a linear
+ * fashion, allowing for faster queries.
+ */
+internal open class MutableEventLogImpl : MutableEventLog {
+
+  // Store what we've already seen.
+  private val acknowledgedMap = MutableAcknowledgeMap()
+
+  // Storing the events and the changes.
+  internal val eventStore = BlockLog()
+  private val eventStoreBySite = mutableMapOf<SiteIdentifier, BlockLog>()
+
+  override val size: Int
+    get() = eventStore.size
+
+  /**
+   * Returns true if the insertion of an event with [seqno] and [site] would require moving back in
+   * the log. If the event could be inserted at the current index, `true` will be returned.
+   */
+  private fun shouldInsertBefore(
+      seqno: SequenceNumber,
+      site: SiteIdentifier,
+  ): Boolean {
+    return eventStore.hasPrevious && EventIdentifier(seqno, site) <= eventStore.lastId
+  }
+
+  /**
+   * Moves the event cursor back, dismissing all the changes associated with the current event if
+   * needed.
+   */
+  open fun moveLeft() {
+    check(eventStore.hasPrevious) { "Can't move backward if at start." }
+
+    // Move the event to the right of the cursor. The event cursor is shifted only after it has been
+    // reversed with all the changes, to ensure that the content is read (and not the gap, which may
+    // have unreliable data).
+    eventStore.moveLeft()
+  }
+
+  /**
+   * Moves the projection forward, meaning that the event at the current cursor index will be used
+   * to generate some changes and move the aggregated value forward.
+   */
+  open fun moveRight() {
+    eventStore.moveRight()
+  }
+
+  override fun insert(
+      seqno: SequenceNumber,
+      site: SiteIdentifier,
+      event: ByteArray,
+      from: Int,
+      until: Int
+  ) {
+
+    // Input sanitization.
+    require(seqno.isSpecified)
+    require(site.isSpecified)
+    requireRange(from, until, event)
+
+    // State checks
+    check(!eventStore.hasNext) { "cursor should be at end" }
+
+    // Fast return.
+    if (acknowledgedMap.contains(seqno, site)) return
+
+    // Insert the event.
+    acknowledge(seqno, site)
+    while (shouldInsertBefore(seqno, site)) moveLeft()
+    eventStore.pushAtGapWithoutMove(
+        id = EventIdentifier(seqno, site),
+        array = event,
+        from = from,
+        until = until,
+    )
+    eventStoreBySite
+        .getOrPut(site) { BlockLog() }
+        .pushAtId(
+            id = EventIdentifier(seqno, site),
+            array = event,
+            from = from,
+            until = until,
+        )
+    while (eventStore.hasNext) moveRight()
+  }
+
+  override fun contains(
+      seqno: SequenceNumber,
+      site: SiteIdentifier,
+  ): Boolean = acknowledgedMap.contains(seqno, site)
+
+  override fun append(
+      site: SiteIdentifier,
+      event: ByteArray,
+      from: Int,
+      until: Int
+  ): EventIdentifier {
+    val seqno = acknowledgedMap.expected()
+    insert(
+        site = site,
+        seqno = seqno,
+        event = event,
+        from = from,
+        until = until,
+    )
+    return EventIdentifier(seqno, site)
+  }
+
+  override fun acknowledge(
+      seqno: SequenceNumber,
+      site: SiteIdentifier,
+  ): Unit = acknowledgedMap.acknowledge(seqno, site)
+
+  override fun acknowledge(
+      from: EventLog,
+  ): MutableEventLog {
+    acknowledgedMap.acknowledge(from.acknowledged())
+    return this
+  }
+
+  override fun acknowledged(): EventIdentifierArray = acknowledgedMap.toEventIdentifierArray()
+
+  override fun iterator(): EventIterator = eventStore.Iterator()
+
+  override fun iterator(
+      site: SiteIdentifier,
+  ): EventIterator {
+    require(site.isSpecified) { "Site must be specified." }
+    return eventStoreBySite[site]?.Iterator() ?: EmptyEventIterator
+  }
+
+  override fun merge(
+      from: EventLog,
+  ): MutableEventLog {
+
+    // Fast success.
+    if (from.size == 0) return this
+
+    val iterator = from.iterator()
+    while (iterator.hasPrevious()) iterator.movePrevious()
+
+    // TODO : Only reverse up to the from lower bound.
+    // TODO : Optimize to avoid "backward-then-forward" for each event.
+    var keepGoing = true
+    while (keepGoing) {
+      insert(
+          seqno = iterator.seqno,
+          site = iterator.site,
+          event = iterator.event,
+          from = iterator.from,
+          until = iterator.until,
+      )
+      keepGoing = iterator.hasNext()
+      if (keepGoing) iterator.moveNext()
+    }
+    return this
+  }
+
+  override fun clear() {
+    eventStore.clear()
+    eventStoreBySite.clear()
+  }
+}

--- a/echo-core/src/commonMain/kotlin/io/github/alexandrepiveteau/echo/core/log/MutableHistoryImpl.kt
+++ b/echo-core/src/commonMain/kotlin/io/github/alexandrepiveteau/echo/core/log/MutableHistoryImpl.kt
@@ -1,8 +1,5 @@
 package io.github.alexandrepiveteau.echo.core.log
 
-import io.github.alexandrepiveteau.echo.core.causality.*
-import io.github.alexandrepiveteau.echo.core.requireRange
-
 /**
  * An implementation of a [MutableHistory], with an initial aggregate, and a projection that is used
  * to incrementally update the model.
@@ -10,33 +7,11 @@ import io.github.alexandrepiveteau.echo.core.requireRange
 internal class MutableHistoryImpl<T>(
     initial: T,
     private val projection: MutableProjection<T>,
-) : MutableHistory<T> {
+) : MutableEventLogImpl(), MutableHistory<T> {
 
   // The ChangeScope that will be provided to the projection whenever some changes mush be appended
   // to the changes history.
-  private val scope = ChangeScope(this::change)
-
-  // Store what we've already seen.
-  private val acknowledged = MutableAcknowledgeMap()
-
-  // Storing the events and the changes.
-  private val eventStore = BlockLog()
-  private val eventStoreBySite = mutableMapOf<SiteIdentifier, BlockLog>()
-  private val changeStore = BlockLog()
-
-  /**
-   * Appends the provided change to the store of changes. The given change will be appended at the
-   * current index of changes.
-   *
-   * @param array the bytes that compose the change.
-   * @param from where the bytes should be read.
-   * @param until where the bytes should be read.
-   */
-  private fun change(
-      array: ByteArray,
-      from: Int,
-      until: Int,
-  ) {
+  private val scope = ChangeScope { array, from, until ->
     changeStore.pushAtGap(
         id = eventStore.lastId,
         array = array,
@@ -45,24 +20,9 @@ internal class MutableHistoryImpl<T>(
     )
   }
 
-  /**
-   * Returns true if the insertion of an event with [seqno] and [site] would require moving back in
-   * the log. If the event could be inserted at the current index, `true` will be returned.
-   */
-  private fun shouldInsertBefore(
-      seqno: SequenceNumber,
-      site: SiteIdentifier,
-  ): Boolean {
-    return eventStore.hasPrevious && EventIdentifier(seqno, site) <= eventStore.lastId
-  }
+  private val changeStore = BlockLog()
 
-  /**
-   * Moves the event cursor back, dismissing all the changes associated with the current event if
-   * needed.
-   */
-  private fun moveCursorLeft() {
-    check(eventStore.hasPrevious) { "Can't move backward if at start." }
-
+  override fun moveLeft() {
     // Remove all the associated changes.
     reverseChange@ while (changeStore.hasPrevious) {
 
@@ -86,153 +46,29 @@ internal class MutableHistoryImpl<T>(
       changeStore.removeLeft()
     }
 
-    // Move the event to the right of the cursor. The event cursor is shifted only after it has been
-    // reversed with all the changes, to ensure that the content is read (and not the gap, which may
-    // have unreliable data).
-    eventStore.moveLeft()
+    // Move the event log.
+    super.moveLeft()
   }
 
-  /**
-   * Moves the projection forward, meaning that the event at the current cursor index will be used
-   * to generate some changes and move the aggregated value forward.
-   */
-  private fun forwardChanges() {
-    eventStore.moveRight()
-
-    val id = eventStore.lastId
-    val from = eventStore.lastFrom
-    val until = eventStore.lastUntil
+  override fun moveRight() {
+    // Move the event log.
+    super.moveRight()
 
     // Update the current value.
     current =
         with(projection) {
           scope.forward(
               model = current,
-              identifier = id,
+              identifier = eventStore.lastId,
               data = eventStore.backing,
-              from = from,
-              until = until,
+              from = eventStore.lastFrom,
+              until = eventStore.lastUntil,
           )
         }
   }
 
-  override val size: Int
-    get() = eventStore.size
-
-  override fun contains(
-      seqno: SequenceNumber,
-      site: SiteIdentifier,
-  ): Boolean = acknowledged.contains(seqno, site)
-
-  override fun insert(
-      seqno: SequenceNumber,
-      site: SiteIdentifier,
-      event: ByteArray,
-      from: Int,
-      until: Int
-  ) {
-
-    // Input sanitization.
-    require(seqno.isSpecified)
-    require(site.isSpecified)
-    requireRange(from, until, event)
-
-    // State checks
-    check(!eventStore.hasNext) { "cursor should be at end" }
-
-    // Fast return.
-    if (acknowledged.contains(seqno, site)) return
-
-    // Insert the event.
-    acknowledge(seqno, site)
-    while (shouldInsertBefore(seqno, site)) moveCursorLeft()
-    eventStore.pushAtGapWithoutMove(
-        id = EventIdentifier(seqno, site),
-        array = event,
-        from = from,
-        until = until,
-    )
-    eventStoreBySite
-        .getOrPut(site) { BlockLog() }
-        .pushAtId(
-            id = EventIdentifier(seqno, site),
-            array = event,
-            from = from,
-            until = until,
-        )
-    while (eventStore.hasNext) forwardChanges()
-  }
-
-  override fun append(
-      site: SiteIdentifier,
-      event: ByteArray,
-      from: Int,
-      until: Int
-  ): EventIdentifier {
-    val seqno = acknowledged.expected()
-    insert(
-        site = site,
-        seqno = seqno,
-        event = event,
-        from = from,
-        until = until,
-    )
-    return EventIdentifier(seqno, site)
-  }
-
-  override fun acknowledge(
-      seqno: SequenceNumber,
-      site: SiteIdentifier,
-  ): Unit = acknowledged.acknowledge(seqno, site)
-
-  override fun acknowledge(
-      from: EventLog,
-  ): MutableEventLog {
-    acknowledged.acknowledge(from.acknowledged())
-    return this
-  }
-
-  override fun acknowledged(): EventIdentifierArray = acknowledged.toEventIdentifierArray()
-
-  override fun iterator(): EventIterator = eventStore.Iterator()
-
-  override fun iterator(
-      site: SiteIdentifier,
-  ): EventIterator {
-    require(site.isSpecified) { "Site must be specified." }
-    return eventStoreBySite[site]?.Iterator() ?: EmptyEventIterator
-  }
-
-  override fun merge(
-      from: EventLog,
-  ): MutableEventLog {
-
-    // Fast success.
-    if (from.size == 0) return this
-
-    val iterator = from.iterator()
-    while (iterator.hasPrevious()) iterator.movePrevious()
-
-    // TODO : Only reverse up to the from lower bound.
-    // TODO : Optimize to avoid "backward-then-forward" for each event.
-    var keepGoing = true
-    while (keepGoing) {
-      insert(
-          seqno = iterator.seqno,
-          site = iterator.site,
-          event = iterator.event,
-          from = iterator.from,
-          until = iterator.until,
-      )
-      keepGoing = iterator.hasNext()
-      if (keepGoing) iterator.moveNext()
-    }
-    return this
-  }
-
   override fun clear() {
-    eventStore.clear()
-    eventStoreBySite.clear()
+    super.clear()
     changeStore.clear()
   }
 

--- a/echo/api/echo.api
+++ b/echo/api/echo.api
@@ -28,6 +28,9 @@ public abstract interface class io/github/alexandrepiveteau/echo/Site : io/githu
 }
 
 public final class io/github/alexandrepiveteau/echo/SiteKt {
+	public static final fun exchange ([Lkotlin/Pair;Lio/github/alexandrepiveteau/echo/sync/SyncStrategy;)Lio/github/alexandrepiveteau/echo/Exchange;
+	public static synthetic fun exchange$default ([Lkotlin/Pair;Lio/github/alexandrepiveteau/echo/sync/SyncStrategy;ILjava/lang/Object;)Lio/github/alexandrepiveteau/echo/Exchange;
+	public static final fun orderedExchange ([Lkotlin/Pair;Lio/github/alexandrepiveteau/echo/sync/SyncStrategy;)Lio/github/alexandrepiveteau/echo/Exchange;
 	public static final fun orderedMutableSite-NmxoKHA (ILjava/lang/Object;Lio/github/alexandrepiveteau/echo/core/log/MutableProjection;Lkotlinx/serialization/KSerializer;Lkotlinx/serialization/BinaryFormat;[Lkotlin/Pair;Lio/github/alexandrepiveteau/echo/sync/SyncStrategy;Lkotlin/jvm/functions/Function1;)Lio/github/alexandrepiveteau/echo/MutableSite;
 	public static final fun orderedSite (Ljava/lang/Object;Lio/github/alexandrepiveteau/echo/core/log/MutableProjection;Lkotlinx/serialization/KSerializer;Lkotlinx/serialization/BinaryFormat;[Lkotlin/Pair;Lio/github/alexandrepiveteau/echo/sync/SyncStrategy;Lkotlin/jvm/functions/Function1;)Lio/github/alexandrepiveteau/echo/Site;
 }

--- a/echo/src/commonMain/kotlin/io/github/alexandrepiveteau/echo/protocol/Sites.kt
+++ b/echo/src/commonMain/kotlin/io/github/alexandrepiveteau/echo/protocol/Sites.kt
@@ -1,9 +1,6 @@
 package io.github.alexandrepiveteau.echo.protocol
 
-import io.github.alexandrepiveteau.echo.Link
-import io.github.alexandrepiveteau.echo.MutableSite
-import io.github.alexandrepiveteau.echo.Site
-import io.github.alexandrepiveteau.echo.channelLink
+import io.github.alexandrepiveteau.echo.*
 import io.github.alexandrepiveteau.echo.core.causality.EventIdentifier
 import io.github.alexandrepiveteau.echo.core.causality.SiteIdentifier
 import io.github.alexandrepiveteau.echo.core.log.EventLog
@@ -28,38 +25,33 @@ import kotlinx.coroutines.yield
 import kotlinx.serialization.BinaryFormat
 import kotlinx.serialization.KSerializer
 
-internal open class SiteImpl<T, M, R>(
-    private val history: MutableHistory<R>,
-    serializer: KSerializer<T>,
-    format: BinaryFormat,
-    vararg events: Pair<EventIdentifier, T>,
+internal open class ExchangeImpl(
+    private val log: MutableEventLog,
+    vararg events: Pair<EventIdentifier, ByteArray>,
     private val strategy: SyncStrategy,
-    private val transform: (R) -> M,
-) : Site<M> {
+) : Exchange<Inc, Out> {
 
-  // Pre-populate with the initial events of the log.
   init {
-    for ((id, body) in events) {
-      history.insert(id.seqno, id.site, format.encodeToByteArray(serializer, body))
-    }
+    // Pre-populate with the initial events of the log.
+    for ((id, body) in events) log.insert(id.seqno, id.site, body)
   }
 
-  /**
-   * The current [history] value. Accesses to set the [current] value are protected through mutual
-   * exclusion via the [Mutex] variable.
-   */
-  internal val current = MutableStateFlow(transform(history.current))
-
-  /** The [Mutex] that protects access to the [current] and [sentinel] variables. */
+  /** The [Mutex] that protects access to the [sentinel] variable. */
   internal val mutex = Mutex()
 
   /**
-   * A sentinel [MutableStateFlow] that can be used to observe invalidations of the [history].
-   * Whenever a site gains mutual exclusion to the []
+   * A sentinel [MutableStateFlow] that can be used to observe invalidations of the [log]. Whenever
+   * a site gains mutual exclusion to the [MutableEventLog].
    */
-  internal val sentinel = MutableStateFlow(UInt.MIN_VALUE)
+  private val sentinel = MutableStateFlow(UInt.MIN_VALUE)
 
-  override val value = current.asStateFlow()
+  /**
+   * A function that will be called whenever some mutations were performed, and some computed values
+   * or the event log should be updated.
+   */
+  open fun mutation() {
+    sentinel.value = sentinel.value + 1U
+  }
 
   /**
    * Runs an exchange in an [ExchangeBlock]. The implementation of the exchange may be a finite
@@ -74,11 +66,7 @@ internal open class SiteImpl<T, M, R>(
       block: ExchangeBlock<I, O>,
   ): Link<I, O> = channelLink { inc ->
     val channel = sentinel.produceIn(this)
-    val publish = {
-      current.value = transform(history.current)
-      sentinel.value = sentinel.value + 1U
-    }
-    val scope = ExchangeScopeImpl(mutex, history, channel, inc, this, publish)
+    val scope = ExchangeScopeImpl(mutex, log, channel, inc, this, ::mutation)
 
     // Give the other threads a chance to run and generate some (termination ?) messages, and then
     // launch our exchange.
@@ -94,19 +82,38 @@ internal open class SiteImpl<T, M, R>(
   override fun incoming() = exchange<Out, Inc> { with(strategy) { incoming() } }
 }
 
+internal open class SiteImpl<M, R>(
+    private val history: MutableHistory<R>,
+    vararg events: Pair<EventIdentifier, ByteArray>,
+    strategy: SyncStrategy,
+    private val transform: (R) -> M,
+) : ExchangeImpl(history, events = events, strategy), Site<M> {
+
+  /**
+   * The current [history] value. Accesses to set the [current] value are protected through mutual
+   * exclusion via the [Mutex] variable.
+   */
+  internal val current = MutableStateFlow(transform(history.current))
+
+  override val value = current.asStateFlow()
+
+  override fun mutation() {
+    current.value = transform(history.current)
+    super.mutation()
+  }
+}
+
 internal open class MutableSiteImpl<T, M, R>(
     override val identifier: SiteIdentifier,
     private val serializer: KSerializer<T>,
     history: MutableHistory<R>,
     format: BinaryFormat,
-    vararg events: Pair<EventIdentifier, T>,
+    vararg events: Pair<EventIdentifier, ByteArray>,
     strategy: SyncStrategy,
     transform: (R) -> M,
 ) :
-    SiteImpl<T, M, R>(
+    SiteImpl<M, R>(
         history = history,
-        serializer = serializer,
-        format = format,
         events = events,
         strategy = strategy,
         transform = transform,
@@ -115,12 +122,12 @@ internal open class MutableSiteImpl<T, M, R>(
 
   private val scope =
       object : EventScope<T> {
-        override fun yield(event: T): EventIdentifier {
-          val id = history.append(identifier, format.encodeToByteArray(serializer, event))
-          current.value = transform(history.current)
-          sentinel.value = sentinel.value + 1U
-          return id
-        }
+        override fun yield(event: T): EventIdentifier =
+            history.append(
+                    site = identifier,
+                    event = format.encodeToByteArray(serializer, event),
+                )
+                .apply { mutation() }
       }
 
   override suspend fun event(

--- a/markdown-backend/src/main/kotlin/io/github/alexandrepiveteau/markdown/backend/SiteMap.kt
+++ b/markdown-backend/src/main/kotlin/io/github/alexandrepiveteau/markdown/backend/SiteMap.kt
@@ -1,10 +1,12 @@
 package io.github.alexandrepiveteau.markdown.backend
 
+import io.github.alexandrepiveteau.echo.Exchange
 import io.github.alexandrepiveteau.echo.Site
-import io.github.alexandrepiveteau.echo.site
+import io.github.alexandrepiveteau.echo.exchange
+import io.github.alexandrepiveteau.echo.protocol.Message.Incoming
+import io.github.alexandrepiveteau.echo.protocol.Message.Outgoing
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import party.markdown.MarkdownPartyEvent
 
 /**
  * A [SiteMap] provides safe access to all the [Site] which are managed by this server. Each site is
@@ -19,7 +21,7 @@ class SiteMap {
   private val mutex = Mutex()
 
   /** A [MutableMap] of the [Site] associated with each [SessionIdentifier]. */
-  private val sites = mutableMapOf<SessionIdentifier, Site<*>>()
+  private val sites = mutableMapOf<SessionIdentifier, Exchange<Incoming, Outgoing>>()
 
   /**
    * Returns the [Site] associated with the given [SessionIdentifier]. This method is safe to call
@@ -29,5 +31,5 @@ class SiteMap {
    */
   suspend fun get(
       identifier: SessionIdentifier,
-  ): Site<*> = mutex.withLock { sites.getOrPut(identifier) { site<MarkdownPartyEvent>() } }
+  ): Exchange<Incoming, Outgoing> = mutex.withLock { sites.getOrPut(identifier) { exchange() } }
 }


### PR DESCRIPTION
This PR implements the more specific `exchange()` builder, and removes the need for `UnitProjection` in the `mutableEventLog()` implementation, since it's not based on `MutableHistoryImpl` anymore.

The `exchange()` builder acts as an operation-type agnostic exchange, which doesn't aggregate a model. It's now used in the replication server for [markdown.party](https://markdown.party).