### PR TITLE
Implement optimized `MutableEventLogImpl.merge()` algorithm

### DIFF
--- a/echo-core/src/commonMain/kotlin/io/github/alexandrepiveteau/echo/core/log/BlockLog.kt
+++ b/echo-core/src/commonMain/kotlin/io/github/alexandrepiveteau/echo/core/log/BlockLog.kt
@@ -34,10 +34,17 @@ internal class BlockLog {
   val hasPrevious: Boolean
     get() = blocksIds.gap.startIndex > 0
 
-  val hasNext: Boolean
+  val hasCurrent: Boolean
     get() = blocksIds.gap.startIndex < blocksIds.size
 
   // END : POSITION
+
+  // BEGIN : CURRENT GAP POSITION
+
+  val currentId: EventIdentifier
+    get() = blocksIds[blocksIds.gap.startIndex]
+
+  // END : CURRENT GAP POSITION
 
   // BEGIN : LAST GAP POSITION
 
@@ -73,7 +80,7 @@ internal class BlockLog {
 
   /** Moves the cursor to the right by one step. */
   fun moveRight() {
-    check(hasNext) { "Can't move right when at last index." }
+    check(hasCurrent) { "Can't move right when at last index." }
     blocksIds.gap.shift(1)
     blocksSizes.gap.shift(1) // Updating lastSize for blocks.gap shift.
     blocks.gap.shift(lastSize)

--- a/echo/src/commonTest/kotlin/io/github/alexandrepiveteau/echo/ScalabilityTest.kt
+++ b/echo/src/commonTest/kotlin/io/github/alexandrepiveteau/echo/ScalabilityTest.kt
@@ -98,9 +98,12 @@ class ScalabilityTest {
         ((historyDuration.inWholeMilliseconds.toFloat() /
                 exchangeDuration.inWholeMilliseconds.toFloat()) * 100)
             .roundToInt()
+    val historyOps = ops * 1000.0 / historyDuration.inWholeMilliseconds
+    val exchangeOps = ops * 1000.0 / exchangeDuration.inWholeMilliseconds
 
-    // Measured performance : speed of 125% - 150%.
-    println("Took ${historyDuration.inWholeMilliseconds} ms for history.")
-    println("Took ${exchangeDuration.inWholeMilliseconds} ms for exchange (speed ${speed}%).")
+    // Measured performance (history)  :       25'000 ops/sec
+    // Measured performance (exchange) :       35'000 ops/sec (125% - 150%)
+    println("Took ${historyDuration.inWholeMilliseconds} ms for history, at $historyOps ops/sec.")
+    println("Took ${exchangeDuration.inWholeMilliseconds} ms for exchange (speed ${speed}%), at $exchangeOps ops/sec.")
   }
 }


### PR DESCRIPTION
Merging two event logs will result in a single "backward-then-forward" move, rather than one move for each insertion.

This will fix #121.