### PR TITLE
Fix a race condition and close #132

### DIFF
--- a/echo-core/api/echo-core.api
+++ b/echo-core/api/echo-core.api
@@ -250,6 +250,7 @@ public final class io/github/alexandrepiveteau/echo/core/causality/EventIdentifi
 
 public final class io/github/alexandrepiveteau/echo/core/causality/EventIdentifierArray {
 	public fun <init> (I)V
+	public final fun contains--MgKYFQ (J)Z
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun get-UaA2Q5I (I)J
 	public final fun getSize ()I

--- a/echo-core/src/commonMain/kotlin/io/github/alexandrepiveteau/echo/core/causality/EventIdentifierArray.kt
+++ b/echo-core/src/commonMain/kotlin/io/github/alexandrepiveteau/echo/core/causality/EventIdentifierArray.kt
@@ -36,6 +36,13 @@ internal constructor(
     return backing.hashCode()
   }
 
+  operator fun contains(identifier: EventIdentifier): Boolean {
+    for (i in 0 until size) {
+      if (get(i) == identifier) return true
+    }
+    return false
+  }
+
   /**
    * Returns the array element at the given [index]. This method can be called using the index
    * operator.


### PR DESCRIPTION
- Add `contains` to `EventIdentifierArray`
- Fix a subtle race condition in CodeMirror integration

---

The reconciliation algorithm didn't account for local removals that had not been sent to the `MutableSite` yet. Therefore, each time the reconciliation algorithm ran (on average, one time per second with a single user, since that's the poll rate of events), the last backspace event may have been skipped.

This race only occurred when the character deletion was not known by the site yet.