### PR TITLE
Add an index on `session` in IndexedDB persistence

### DIFF
--- a/library/echo-indexeddb/src/main/kotlin/io/github/alexandrepiveteau/echo/indexeddb/Open.kt
+++ b/library/echo-indexeddb/src/main/kotlin/io/github/alexandrepiveteau/echo/indexeddb/Open.kt
@@ -1,18 +1,27 @@
 package io.github.alexandrepiveteau.echo.indexeddb
 
 import com.juul.indexeddb.Database
+import com.juul.indexeddb.VersionChangeTransaction
 import com.juul.indexeddb.openDatabase
 
 /** The name of the database where events are stored. */
 private const val Name = "echo"
 
 /** The version of the schema. */
-private const val Version = 2
+private const val Version = 3
 
 /** Opens and returns the [Database] to be used to store events. */
 internal suspend fun openDatabase(): Database =
     openDatabase(Name, Version) { database, oldVersion, _ ->
-      if (oldVersion != Version) {
-        database.createObjectStore(EventsStore, EventIdPath)
-      }
+      if (oldVersion < 2) from0To2(database)
+      if (oldVersion < 3) from2To3()
     }
+
+// UPGRADE SCRIPTS
+
+private fun VersionChangeTransaction.from0To2(
+    database: Database,
+) = with(database) { createObjectStore(EventsStore, EventIdPath) }
+
+private fun VersionChangeTransaction.from2To3() =
+    objectStore(EventsStore).createIndex(SessionIndex, SessionPath, unique = false)

--- a/library/echo-indexeddb/src/main/kotlin/io/github/alexandrepiveteau/echo/indexeddb/Persistence.kt
+++ b/library/echo-indexeddb/src/main/kotlin/io/github/alexandrepiveteau/echo/indexeddb/Persistence.kt
@@ -1,5 +1,6 @@
 package io.github.alexandrepiveteau.echo.indexeddb
 
+import com.juul.indexeddb.Key
 import io.github.alexandrepiveteau.echo.Exchange
 import io.github.alexandrepiveteau.echo.core.buffer.copyOfRange
 import io.github.alexandrepiveteau.echo.core.log.Event
@@ -54,10 +55,9 @@ suspend fun load(session: String, exchange: Exchange<Incoming, Outgoing>) {
         val log = mutableEventLogOf()
         val events =
             objectStore(EventsStore)
-                .getAll()
-                .map { it.unsafeCast<StoredEvent>() }
-                .filter { it.session == session }
-                .map { it.toEvent() }
+                .index(SessionIndex)
+                .getAll(Key(session))
+                .map { it.unsafeCast<StoredEvent>().toEvent() }
                 .sortedBy { it.seqno }
         events.forEach { event ->
           log.insert(

--- a/library/echo-indexeddb/src/main/kotlin/io/github/alexandrepiveteau/echo/indexeddb/StoredEvent.kt
+++ b/library/echo-indexeddb/src/main/kotlin/io/github/alexandrepiveteau/echo/indexeddb/StoredEvent.kt
@@ -10,6 +10,12 @@ import kotlinx.js.jso
 /** The [KeyPath] for the keys of [StoredEvent]. */
 internal val EventIdPath = KeyPath("session", "site", "seqno")
 
+/** The [KeyPath] for a single session. */
+internal val SessionPath = KeyPath("session")
+
+/** The index for the session key. */
+internal const val SessionIndex = "session"
+
 /** The path for the events object store. */
 internal const val EventsStore = "events"
 


### PR DESCRIPTION
The additional index makes fetching events for a given session more efficient, which considerably helps when a user has multiple collaborative sessions.